### PR TITLE
Remove Animated Flag

### DIFF
--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -503,7 +503,6 @@ class ThumbnailService
     {
         return $media->getMediaType() instanceof ImageType
             && !$media->getMediaType()->is(ImageType::VECTOR_GRAPHIC)
-            && !$media->getMediaType()->is(ImageType::ANIMATED)
             && !$media->getMediaType()->is(ImageType::ICON);
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Because default webp-images couldn't not be generated, because most webp images have a ANIMATED flag.

### 2. What does this change do, exactly?
Remove the ANIMATED flag from thumbnailsAreGeneratable method.

### 3. Describe each step to reproduce the issue or behaviour.
Upload a webp image to the media gallery. 

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
